### PR TITLE
feat: Add TieredDiscount pricing strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ strategy_app/
 - **NoDiscount** – leaves subtotal unchanged.
 - **PercentageDiscount** – applies a percentage discount to the subtotal.
 - **BulkItemDiscount** – if a particular SKU quantity reaches a threshold, subtract a per-item amount.
+- **TieredDiscount** – applies different discount percentages based on subtotal amount tiers.
 - **CompositeStrategy** – combine multiple strategies and apply them in order.
 
 ## Run CLI
@@ -38,6 +39,15 @@ python -m presentation.cli --items '[{"sku":"A","qty":2,"unit_price":10.0},{"sku
 # Subtotal: 35.00
 # Strategy: bulk
 # Total: 32.50
+```
+
+Tiered strategy (different discounts based on subtotal):
+
+```bash
+python -m presentation.cli --items '[{"sku":"A","qty":10,"unit_price":15.0},{"sku":"B","qty":5,"unit_price":10.0}]' --strategy tiered --tiers "50:5,100:10,200:15"
+# Subtotal: 200.00
+# Strategy: tiered
+# Total: 170.00 (15% discount for >= $200)
 ```
 
 Composite strategy (percent then bulk):

--- a/application/bootstrap.py
+++ b/application/bootstrap.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from domain.pricing import PricingStrategy, NoDiscount, PercentageDiscount, BulkItemDiscount, CompositeStrategy
+from domain.pricing import PricingStrategy, NoDiscount, PercentageDiscount, BulkItemDiscount, CompositeStrategy, TieredDiscount
 
 
 def choose_strategy(kind: str, **kwargs) -> PricingStrategy:
@@ -14,6 +14,14 @@ def choose_strategy(kind: str, **kwargs) -> PricingStrategy:
             threshold=int(kwargs.get("threshold", 0)),
             per_item_off=float(kwargs.get("per_item_off", 0.0)),
         )
+    if kind == "tiered":
+        # Parse tiers from comma-separated list of "threshold:percent" pairs
+        tiers_str = kwargs.get("tiers", "0:0")
+        tiers = []
+        for tier_str in tiers_str.split(","):
+            threshold_str, percent_str = tier_str.strip().split(":")
+            tiers.append((float(threshold_str), float(percent_str)))
+        return TieredDiscount(tiers)
     if kind == "composite":
         # Example: combine percent then bulk
         percent = PercentageDiscount(kwargs.get("percent", 0.0))

--- a/domain/pricing.py
+++ b/domain/pricing.py
@@ -47,6 +47,40 @@ class BulkItemDiscount(PricingStrategy):
         return round(max(total, 0.0), 2)
 
 
+class TieredDiscount(PricingStrategy):
+    """Apply different discount percentages based on subtotal amount tiers."""
+    def __init__(self, tiers: list[tuple[float, float]]) -> None:
+        """Initialize with tiers list of (threshold, discount_percent).
+        
+        Args:
+            tiers: List of (threshold, discount_percent) tuples. The first threshold
+                  that the subtotal meets or exceeds determines the discount rate.
+                  Tiers should be ordered from lowest to highest threshold.
+        
+        Example: tiers=[(50.0, 5.0), (100.0, 10.0), (200.0, 15.0)]
+                means 5% off for >=$50, 10% off for >=$100, 15% off for >=$200
+        """
+        assert len(tiers) > 0, "At least one tier is required"
+        for threshold, percent in tiers:
+            assert threshold >= 0, "Threshold must be non-negative"
+            assert 0 <= percent <= 100, "Discount percent must be between 0 and 100"
+        
+        # Sort tiers by threshold to ensure proper ordering
+        self.tiers = sorted(tiers, key=lambda x: x[0])
+
+    def apply(self, subtotal: float, items: list[LineItem]) -> float:
+        # Find the highest threshold that the subtotal meets or exceeds
+        discount_percent = 0.0
+        for threshold, percent in self.tiers:
+            if subtotal >= threshold:
+                discount_percent = percent
+            else:
+                break
+        
+        discount = subtotal * (discount_percent / 100.0)
+        return round(subtotal - discount, 2)
+
+
 class CompositeStrategy(PricingStrategy):
     """Compose multiple strategies; apply in order."""
     def __init__(self, strategies: list[PricingStrategy]) -> None:

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -15,19 +15,22 @@ def main() -> None:
     parser.add_argument("--items", type=str, required=True,
                         help='JSON list of items: [{"sku":"A","qty":2,"unit_price":10.0}, ...]')
     parser.add_argument("--strategy", type=str, default="none",
-                        choices=["none", "percent", "bulk", "composite"],
+                        choices=["none", "percent", "bulk", "tiered", "composite"],
                         help="Strategy kind")
     parser.add_argument("--percent", type=float, default=0.0, help="Percent discount for 'percent' or 'composite'")
     parser.add_argument("--sku", type=str, default="", help="SKU for bulk/composite")
     parser.add_argument("--threshold", type=int, default=0, help="Qty threshold for bulk/composite")
     parser.add_argument("--per-item-off", type=float, default=0.0, dest="per_item_off",
                         help="Per item discount for bulk/composite")
+    parser.add_argument("--tiers", type=str, default="0:0",
+                        help='Tiered discount tiers: "50:5,100:10,200:15" (threshold:percent pairs)')
     args = parser.parse_args()
 
     items = parse_items(args.items)
     subtotal = compute_subtotal(items)
     strat = choose_strategy(args.strategy, percent=args.percent, sku=args.sku,
-                            threshold=args.threshold, per_item_off=args.per_item_off)
+                            threshold=args.threshold, per_item_off=args.per_item_off,
+                            tiers=args.tiers)
     total = strat.apply(subtotal, items)
 
     print(f"Subtotal: {subtotal:.2f}")

--- a/tests/test_strategies_unit.py
+++ b/tests/test_strategies_unit.py
@@ -1,5 +1,5 @@
 import pytest
-from domain.pricing import LineItem, compute_subtotal, NoDiscount, PercentageDiscount, BulkItemDiscount, CompositeStrategy
+from domain.pricing import LineItem, compute_subtotal, NoDiscount, PercentageDiscount, BulkItemDiscount, CompositeStrategy, TieredDiscount
 
 
 def sample_items():
@@ -38,3 +38,55 @@ def test_composite_applies_in_order():
     # First 10% off => 31.5, then bulk: - (5 * 0.5) = -2.5 => 29.0
     comp = CompositeStrategy([PercentageDiscount(10), BulkItemDiscount("B", 5, 0.5)])
     assert comp.apply(subtotal, items) == 29.0
+
+
+def test_tiered_discount_single_tier():
+    items = sample_items()  # subtotal 35
+    subtotal = compute_subtotal(items)
+    # Single tier: 5% off for >= $30
+    tiered = TieredDiscount([(30.0, 5.0)])
+    total = tiered.apply(subtotal, items)
+    assert total == 33.25  # 35 - (35 * 0.05) = 35 - 1.75 = 33.25
+
+
+def test_tiered_discount_no_tier_matched():
+    items = sample_items()  # subtotal 35
+    subtotal = compute_subtotal(items)
+    # No tier matched (threshold higher than subtotal)
+    tiered = TieredDiscount([(50.0, 10.0)])
+    total = tiered.apply(subtotal, items)
+    assert total == 35.00  # No discount applied
+
+
+def test_tiered_discount_multiple_tiers():
+    items = [
+        LineItem("A", qty=10, unit_price=15.0),  # 150
+        LineItem("B", qty=5, unit_price=10.0),   # 50
+    ]  # subtotal = 200
+    
+    subtotal = compute_subtotal(items)
+    # Multiple tiers: 5% for >=50, 10% for >=100, 15% for >=200
+    tiered = TieredDiscount([(50.0, 5.0), (100.0, 10.0), (200.0, 15.0)])
+    total = tiered.apply(subtotal, items)
+    assert total == 170.00  # 200 - (200 * 0.15) = 200 - 30 = 170
+
+
+def test_tiered_discount_uses_highest_applicable_tier():
+    items = [
+        LineItem("A", qty=8, unit_price=10.0),  # 80
+    ]  # subtotal = 80
+    
+    subtotal = compute_subtotal(items)
+    # Should use 10% tier (not 5%) since 80 >= 50 and 80 >= 100
+    tiered = TieredDiscount([(50.0, 5.0), (100.0, 10.0)])
+    total = tiered.apply(subtotal, items)
+    assert total == 76.00  # 80 - (80 * 0.05) = 80 - 4 = 76
+
+
+def test_tiered_discount_unordered_tiers():
+    items = sample_items()  # subtotal 35
+    subtotal = compute_subtotal(items)
+    # Tiers provided out of order - should be sorted internally
+    tiered = TieredDiscount([(100.0, 15.0), (50.0, 10.0), (0.0, 5.0)])
+    total = tiered.apply(subtotal, items)
+    assert total == 33.25  # 35 - (35 * 0.05) = 35 - 1.75 = 33.25


### PR DESCRIPTION
## Summary
- **New TieredDiscount strategy** that applies different discount percentages based on subtotal amount thresholds
- **CLI integration** with `--tiers` argument for specifying discount tiers via command line
- **Strategy factory support** for creating TieredDiscount instances
- **Comprehensive unit tests** covering various scenarios and edge cases
- **Updated documentation** with usage examples and CLI command reference

## Implementation Details
The TieredDiscount strategy accepts a list of `(threshold, discount_percent)` tuples and automatically applies the highest applicable discount rate. For example, tiers `[(50.0, 5.
0), (100.0, 10.0), (200.0, 15.0)]` would apply:
- 5% discount for subtotals >= $50
- 10% discount for subtotals >= $100
- 15% discount for subtotals >= $200

## CLI Usage
```bash
python -m presentation.cli --items '[{"sku":"A","qty":10,"unit_price":15.0},{"sku":"B","qty":5,"unit_price":10.0}]' --strategy tiered --tiers "50:5,100:10,200:15"
# Subtotal: 200.00
# Strategy: tiered
# Total: 170.00 (15% discount for >= $200)
